### PR TITLE
Switch to the 3-argument version of timespecadd

### DIFF
--- a/nstat.c
+++ b/nstat.c
@@ -52,17 +52,17 @@
 #include <sys/vmmeter.h>
 
 
-/* why is this only defined in the kernel */
-#define	timespecadd(vvp, uvp)						\
-	do {								\
-		(vvp)->tv_sec += (uvp)->tv_sec;				\
-		(vvp)->tv_nsec += (uvp)->tv_nsec;			\
-		if ((vvp)->tv_nsec >= 1000000000) {			\
-			(vvp)->tv_sec++;				\
-			(vvp)->tv_nsec -= 1000000000;			\
-		}							\
-	} while (0)
-
+#ifndef	timespecadd
+#define timespecadd(tsp, usp, vsp)                                      \
+        do {                                                            \
+                (vsp)->tv_sec = (tsp)->tv_sec + (usp)->tv_sec;          \
+                (vsp)->tv_nsec = (tsp)->tv_nsec + (usp)->tv_nsec;       \
+                if ((vsp)->tv_nsec >= 1000000000L) {                    \
+                        (vsp)->tv_sec++;                                \
+                        (vsp)->tv_nsec -= 1000000000L;                  \
+                }                                                       \
+        } while (0)
+#endif
 
 #define SWAP_CPU() { cpu_tmp = cpu; cpu = cpu_prev; cpu_prev = cpu_tmp; }
 double
@@ -468,7 +468,7 @@ main(int argc, char **argv)
 		if (++row == rows)
 			row = 0;
 
-		timespecadd(&deadline_ts, &interval_ts);
+		timespecadd(&deadline_ts, &interval_ts, &deadline_ts);
 		clock_nanosleep(CLOCK_UPTIME, TIMER_ABSTIME, &deadline_ts, NULL);
 	}
 }


### PR DESCRIPTION
nstat defines a private 2-argument timespecadd macro that's a copy of
the FreeBSD kernel's.  But NetBSD, OpenBSD, and FreeDesktop.org's libbsd
all define a public 3-argument timespecadd macro instead.  An upcoming
change to FreeBSD will replace the 2-argument version with the more
common 3-argument version and make it public.

This change brings nstat onto the 3-argument bandwagon and ensures that
it will continue to build on old versions of FreeBSD too.